### PR TITLE
Remove redundant libtensorflow-lite.a from BUILD_BYPRODUCTS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ ExternalProject_Add(tf
     BUILD_IN_SOURCE 1
     BUILD_COMMAND ${TF_COMMAND}
     BUILD_BYPRODUCTS libtensorflow-lite.a ${CMAKE_BINARY_DIR}/tensorflow/src/tf/tensorflow/lite/tools/make/downloads/fft2d/fftsg.c
-    BUILD_BYPRODUCTS libtensorflow-lite.a ${CMAKE_BINARY_DIR}/tensorflow/src/tf/tensorflow/lite/tools/optimize/sparsity/format_converter.cc
+    BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/tensorflow/src/tf/tensorflow/lite/tools/optimize/sparsity/format_converter.cc
     INSTALL_COMMAND cp -f ${CMAKE_BINARY_DIR}/tensorflow/src/tf/tensorflow/lite/tools/make/gen/${TF_INSTALL_PREFIX}/lib/libtensorflow-lite.a ${CMAKE_BINARY_DIR}/
 )
 


### PR DESCRIPTION
`libtensorflow-lite.a` was listed twice in `BUILD_BYPRODUCTS`.  This made `ninja` a very angry ninja.